### PR TITLE
Feature/groupme provider

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -194,5 +194,10 @@ en:
         #######################################
         groupme:
           title: "GroupMe"
+          param:
+            groupme_bot_id:
+              title: "GroupMe Bot ID"
+              help: "the id of the bot set up to post to a particular instance. use 'all' to send to all  instances"
           errors:
             not_found: "The path you attempted to post your message to was not found. Check the Bot ID in Site Settings."
+            instance_names_issue: "instance names incorrectly formatted or not provided"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -83,7 +83,8 @@ en:
     #######################################
     chat_integration_groupme_enabled: "Enable the Groupme chat integration provider"
     chat_integration_groupme_excerpt_length: "Groupme post excerpt length"
-    chat_integration_groupme_bot_ids: "Bot IDs, seperated by ',' if there are multiple"
+    chat_integration_groupme_bot_ids: "*required* Bot IDs, seperated by ',' if there are multiple"
+    chat_integration_groupme_instance_names: " *optional* Name of the GroupMe chat, seperated by ',' if there are multiple (same order as Bot IDs)"
 
   chat_integration:
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -128,3 +128,5 @@ chat_integration:
     default: 400
   chat_integration_groupme_bot_ids:
     default: ''
+  chat_integration_groupme_instance_names:
+    default: ''

--- a/lib/discourse_chat/provider/groupme/groupme_provider.rb
+++ b/lib/discourse_chat/provider/groupme/groupme_provider.rb
@@ -4,7 +4,9 @@ module DiscourseChat::Provider::GroupmeProvider
   
     PROVIDER_ENABLED_SETTING = :chat_integration_groupme_enabled
     # TODO: dynamic options for making channels relate to specific Groupme instances for the multi-bot case
-    CHANNEL_PARAMETERS = []
+    CHANNEL_PARAMETERS = [
+        {key: "groupme_bot_id", unique: true}
+    ]
   
     def self.generate_groupme_message(post)
       display_name = "@#{post.user.username}"
@@ -30,11 +32,19 @@ module DiscourseChat::Provider::GroupmeProvider
 
     end
   
-    def self.send_via_webhook(message)
+    def self.send_via_webhook(message, channel)
       # loop through all the bot IDs
       last_error_raised = nil
       num_errors = 0
       bot_ids = SiteSetting.chat_integration_groupme_bot_ids.split(/\s*,\s*/)
+      instance_names = SiteSettings.chat_integration_groupme_instance_names.split(',')
+      unless instance_names.length() == bot_ids.length()
+        instance_names = ['chat_integration.provider.groupme.errors.instance_names_issue']*bot_ids.length()
+      end
+      id_to_name = Hash[bot_ids.zip(instance_names)]
+      unless channel.data['groupme_bot_id'].eql? 'all'
+        bot_ids = [channel.data.groupme_bot_id]
+      end
       bot_ids.each { |bot_id|
         uri = URI("https://api.groupme.com/v3/bots/post")
         http = Net::HTTP.new(uri.host, uri.port)
@@ -50,7 +60,7 @@ module DiscourseChat::Provider::GroupmeProvider
             else
               error_key = nil
             end
-            last_error_raised = { error_key: error_key, request: req.body, response_code: response.code, response_body: response.body }
+            last_error_raised = { error_key: error_key, groupme_name: id_to_name[:bot_id] request: req.body, response_code: response.code, response_body: response.body }
         end
       }
       if last_error_raised
@@ -62,7 +72,7 @@ module DiscourseChat::Provider::GroupmeProvider
   
     def self.trigger_notification(post, channel)
       data_package = generate_groupme_message(post)
-      self.send_via_webhook(data_package)
+      self.send_via_webhook(data_package, channel)
     end
   end
   


### PR DESCRIPTION
Add the ability to treat each GroupMe like a separate channel. 

Thus users can send specific categories to specific groupme instances. retain the option to use the `all` botid as a keyword to basically broadcast and send it to every groupme listed in the Site Settings.. maybe should have used the word `broadcast` instead of `all` ? eh

e.g.

Category: ChemEng 120A tips -> ChemEng 120A Study Group Chat Room